### PR TITLE
Fix Streamlit Cloud crash by pinning dependency versions and removing…

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,8 +25,6 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 import plotly.graph_objects as go
 from plotly.colors import hex_to_rgb, qualitative, sequential
-import plotly.io as pio
-
 import streamlit as st
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-streamlit>=1.36
-pandas>=2.2
-numpy>=1.26
-matplotlib>=3.8
-plotly>=5.22
-kaleido>=0.2
-openpyxl>=3.1
-xlsxwriter>=3.1
-
+streamlit>=1.36,<2
+pandas>=2.2,<3
+numpy>=1.26,<3
+matplotlib>=3.8,<4
+plotly>=5.22,<6
+openpyxl>=3.1,<4
+xlsxwriter>=3.1,<4


### PR DESCRIPTION
… unused import

The app crashed on Streamlit Community Cloud with "Error running app" because:
- requirements.txt used unbounded `>=` constraints, causing plotly 6.x and kaleido 1.x to be installed on Cloud (vs 5.x/0.x locally)
- kaleido 1.x requires Chrome/Chromium which is not available on Cloud
- The unused `import plotly.io as pio` triggered kaleido initialization

Changes:
- Pin upper bounds on all dependencies to prevent major version jumps
- Remove kaleido (not needed: app uses st.plotly_chart + matplotlib PdfPages)
- Remove unused `import plotly.io as pio`

https://claude.ai/code/session_01NJTbGUYhQJCyZnEEp1bS2x