### PR TITLE
Fix text overlaps in PDF summary by using single-line wrapped layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1542,12 +1542,12 @@ def export_integrity_pdf(summary: dict, dataset_label: str = 'Full dataset',
                 explanations.append((k, desc))
 
         for label, value in bullets:
-            fig, ax, y = _need_space(pdf, fig, ax, y, LINE_H)
-            ax.text(MARGIN_L + 0.01, y, label, ha='left', va='top',
-                    fontsize=9.5, weight='bold', color=C_DARK)
-            ax.text(0.45, y, value, ha='left', va='top',
-                    fontsize=9.5, color=C_TEXT)
-            y -= LINE_H
+            combined = f'{label}:  {value}'
+            for wrapped in textwrap.wrap(combined, width=95):
+                fig, ax, y = _need_space(pdf, fig, ax, y, LINE_H)
+                ax.text(MARGIN_L + 0.01, y, wrapped, ha='left', va='top',
+                        fontsize=9.5, color=C_TEXT)
+                y -= LINE_H
 
         y -= 0.02
         _draw_rule(ax, y)


### PR DESCRIPTION
Long labels and long values were overlapping due to fixed two-column split at x=0.45. Now each summary row renders as a single wrapped line "Label: Value" to prevent any overlap or truncation.

https://claude.ai/code/session_01Azyx7Fi282pXx3kW5TtV2U